### PR TITLE
Fix tests in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-testserver
+/testserver

--- a/builder.go
+++ b/builder.go
@@ -92,15 +92,16 @@ func (b *BasicBuilder) Run() error {
 
 	cmd := exec.Command(b.runCmd[0], b.runCmd[1:]...)
 
-	var stdout []byte
-	var stderr []byte
-	cmd.Stdout = bytes.NewBuffer(stdout)
-	cmd.Stderr = bytes.NewBuffer(stderr)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	err := cmd.Start()
 	b.logger.Debug("run", "cmd", b.runCmd, "err", err, "stdout", stdout, "stderr", stderr)
 	if err != nil {
-		b.errText = err.Error() + "\n\n" + string(stderr)
+		b.logger.Error("run failed", "err", err, "stdout", stdout, "stderr", stderr, "cmd", b.runCmd)
+		b.errText = err.Error() + "\n stdout:" + stdout.String() + "\nstderr:" + stderr.String()
 	} else {
 		b.errText = ""
 		b.running = cmd
@@ -144,15 +145,16 @@ func (b *BasicBuilder) Build() error {
 
 	cmd := exec.Command(b.buildCmd[0], b.buildCmd[1:]...)
 
-	var stdout []byte
-	var stderr []byte
-	cmd.Stdout = bytes.NewBuffer(stdout)
-	cmd.Stderr = bytes.NewBuffer(stderr)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	err := cmd.Run()
 	b.logger.Debug("build", "cmd", b.buildCmd, "err", err, "stdout", stdout, "stderr", stderr)
 	if err != nil {
-		b.errText = err.Error() + "\n\n" + string(stdout) + "\n\n" + string(stderr)
+		b.logger.Error("build failed", "err", err, "stdout", stdout, "stderr", stderr, "cmd", b.runCmd)
+		b.errText = err.Error() + "\n stdout:" + stdout.String() + "\nstderr:" + stderr.String()
 	} else {
 		b.errText = ""
 	}

--- a/internal/testserver/main.go
+++ b/internal/testserver/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "net/http"
+
+func main() {
+	err := http.ListenAndServe(":3012", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello from test server"))
+	}))
+
+	if err != nil && err != http.ErrServerClosed {
+		panic(err)
+	}
+}

--- a/reloader.go
+++ b/reloader.go
@@ -134,7 +134,6 @@ func (app *Application) ListenAndProxy(ctx context.Context, addr string, targetA
 			app.builder.Stop()
 			return ctx.Err()
 		case event := <-events:
-			fmt.Println(event)
 			app.logger.Debug("file changed", "file", event)
 			// Clear existing queue to prevent rapid rebuilds.
 			for i := 0; i < len(events); i++ {

--- a/reloader_test.go
+++ b/reloader_test.go
@@ -3,7 +3,6 @@ package reloader
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -104,8 +103,6 @@ type mockWatcher struct {
 }
 
 func (w *mockWatcher) Watch(ctx context.Context, events chan<- string) error {
-	fmt.Println("calling again")
-	fmt.Println(events)
 	w.events = events
 	return nil
 }
@@ -148,7 +145,6 @@ func TestReloader_FileChange(t *testing.T) {
 	<-done
 
 	logs := strings.Split(b.String(), "\n")
-	fmt.Println(b.String())
 	require.Len(t, logs, 6)
 
 	require.Contains(t, logs[0], "build")

--- a/reloader_test.go
+++ b/reloader_test.go
@@ -23,7 +23,13 @@ func TestIntegration(t *testing.T) {
 		[]string{"go", "build", "-o", "./testserver", "./internal/testserver"},
 		[]string{"./testserver"},
 		logger,
-		func() bool { return true },
+		func() bool {
+			res, err := http.Get("http://localhost:3012")
+			if err != nil {
+				return false
+			}
+			return res.StatusCode == 200
+		},
 	)
 	watcher, err := NewWatcher(".")
 	require.NoError(t, err)


### PR DESCRIPTION
This adds error logs, removes debug `fmt.Println` calls, and fixes CI by removing the gitignore and adding the testserver.